### PR TITLE
v5.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ gradle全局参数：
 
 [查看认证过程](doc/oauth2.0认证.md)
 
+> cloud:oauth-server 中增加 authorization_code 方式配置，详见 pers.acp.springcloud.oauth.conf.WebSecurityConfiguration 注释
+
+> 注：使用 authorization_code 方式时，认证请求时需要直接访问 oauth-server 不能通过 gateway
+
 ##### 6. cloud:log-server
 日志服务，使用 kafka 作为日志消息队列
 ##### 7. cloud:helloworld 

--- a/cloud/acp-spring-cloud-starter-common/src/main/java/pers/acp/springcloud/common/conf/ResourceServerConfiguration.java
+++ b/cloud/acp-spring-cloud-starter-common/src/main/java/pers/acp/springcloud/common/conf/ResourceServerConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.cloud.client.loadbalancer.LoadBalanced;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -22,6 +23,7 @@ import org.springframework.web.client.RestTemplate;
 import pers.acp.client.exceptions.HttpException;
 import pers.acp.client.http.HttpClientBuilder;
 import pers.acp.core.CommonTools;
+import pers.acp.springcloud.common.constant.ConfigurationOrder;
 import pers.acp.springcloud.common.enums.RestPrefix;
 import pers.acp.springcloud.common.log.LogInstance;
 
@@ -34,6 +36,7 @@ import pers.acp.springcloud.common.log.LogInstance;
 @Component
 @Configuration
 @EnableResourceServer
+@Order(ConfigurationOrder.resourceServerConfiguration)
 public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter {
 
     private final LogInstance logInstance;
@@ -134,7 +137,8 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
                 contextPath + "/oauth/token",
                 contextPath + "/oauth/error",
                 contextPath + RestPrefix.OPEN + "/**").permitAll()
-                .anyRequest().authenticated();
+                .anyRequest().authenticated()
+                .and().formLogin().permitAll();
     }
 
 }

--- a/cloud/acp-spring-cloud-starter-common/src/main/java/pers/acp/springcloud/common/constant/ConfigurationOrder.java
+++ b/cloud/acp-spring-cloud-starter-common/src/main/java/pers/acp/springcloud/common/constant/ConfigurationOrder.java
@@ -1,0 +1,11 @@
+package pers.acp.springcloud.common.constant;
+
+/**
+ * @author zhang by 21/01/2019 16:01
+ * @since JDK 11
+ */
+public interface ConfigurationOrder {
+
+    int resourceServerConfiguration = 6;
+
+}

--- a/cloud/oauth-server/src/main/java/pers/acp/springcloud/oauth/conf/WebSecurityConfiguration.java
+++ b/cloud/oauth-server/src/main/java/pers/acp/springcloud/oauth/conf/WebSecurityConfiguration.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.provider.ClientDetailsService;
 import pers.acp.core.CommonTools;
+import pers.acp.springcloud.common.constant.ConfigurationOrder;
 import pers.acp.springcloud.oauth.component.UserPasswordEncoder;
 import pers.acp.springcloud.oauth.domain.SecurityClientDetailsService;
 import pers.acp.springcloud.oauth.domain.SecurityUserDetailsService;
@@ -22,6 +24,8 @@ import pers.acp.springcloud.oauth.domain.SecurityUserDetailsService;
  */
 @Configuration
 @EnableWebSecurity
+@Order(ConfigurationOrder.resourceServerConfiguration + 1)
+// 如果使用 authorization_code 方式，需要 ConfigurationOrder.resourceServerConfiguration - 1 ， 反之则需要 ConfigurationOrder.resourceServerConfiguration + 1
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final String contextPath;
@@ -70,6 +74,9 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 contextPath + "/actuator/**",
                 contextPath + "/oauth/**").permitAll()
                 .anyRequest().authenticated();
+        // 如果使用 authorization_code 方式，则放开以下两行注释
+//                .and()
+//                .formLogin().permitAll();
     }
 
 }

--- a/cloud/oauth-server/src/main/java/pers/acp/springcloud/oauth/domain/SecurityClientDetailsService.java
+++ b/cloud/oauth-server/src/main/java/pers/acp/springcloud/oauth/domain/SecurityClientDetailsService.java
@@ -28,8 +28,9 @@ public class SecurityClientDetailsService implements ClientDetailsService {
         InMemoryClientDetailsServiceBuilder builder = new InMemoryClientDetailsServiceBuilder();
         builder.withClient("test")
                 .secret("test")
-                .authorizedGrantTypes("password", "client_credentials", "refresh_token")
+                .authorizedGrantTypes("authorization_code", "password", "client_credentials", "refresh_token")
                 .authorities("ROLE_ADMIN")
+                .redirectUris("http://www.baidu.com")
                 .scopes("ALL")
                 .accessTokenValiditySeconds(600)
                 .refreshTokenValiditySeconds(86400)

--- a/doc/version_history.md
+++ b/doc/version_history.md
@@ -30,6 +30,7 @@
 > - cloud 模块增加日志服务配置项
 > - acp-spring-cloud-starter-common 增加 acp.cloud.oauth.oauth-server 配置项，oauth-server 可直接引用并修改配置项，不再需要单独编写自己的 ResourceServerConfiguration
 > - 去除无用的依赖
+> - cloud:oauth-server 中增加 authorization_code 方式配置 demo
 ##### v5.0.1
 > - 更新 SpringBoot 至 2.0.6.RELEASE
 > - 更新 SpringCloud 至 Finchley.SR2


### PR DESCRIPTION
> - 更新 SpringBoot 至 2.1.2.RELEASE
> - 更新 SpringCloud 至 Greenwich.RC2
> - 更新依赖包版本
> - cloud 模块下 docker-compose-base.yml 文件修改，修改 zookeeper 端口号，增加 kafka-manager
> - 更新 spring-data-jpa 数据库连接配置及多数据源写法
> - 修改 spring boot 中 logback 配置
> - 更新 kotlin 至 1.3.11
> - 优化定时器配置
> - acp-file 去除 jxl 相关依赖，不再封装 jxl 相关操作
> - 剥离订制工程 [management](https://github.com/zhangbin1010/acp-ace-php-back)
> - 修改核心模块名称
> - 更新 gradle 至 5.1.1
> - cloud 模块下 gateway-server 支持跨域
> - 更新 spring boot admin 至 2.1.1
> - cloud 模块下，oauth-server 优化 token 服务配置，方便自定义扩展
> - 优化全局异常处理，增加 ErrorVO
> - 优化 oauth2 demo
> - cloud helloworld 中增加使用 RestTemplate 通过服务名调用远程服务的例子
> - 优化 REST 日志切片
> - 修改 jdbc mysql 链接字符串，支持 utf8mb4 字符集
> - 修改 DockerFile 内容，通过 kafka 传递信息给 zipkin server，gateway-server 去除 zipkin 相关依赖
> - 增加 swagger 开关配置
> - jackson 工具类增加 propertyNamingStrategy 参数
> - 自定义 spring boot start 中使用内置 jackson 进行 json 操作
> - 去除 Http Request 和 Response 的包裹封装，重写文件下载 controller
> - 核心工具类增加驼峰和下划线命名规则之间互相转化的方法
> - 规范配置项 acp.*
> - cloud 模块增加日志服务配置项
> - acp-spring-cloud-starter-common 增加 acp.cloud.oauth.oauth-server 配置项，oauth-server 可直接引用并修改配置项，不再需要单独编写自己的 ResourceServerConfiguration
> - 去除无用的依赖
> - cloud:oauth-server 中增加 authorization_code 方式配置 demo